### PR TITLE
Fix sinh() always returning NaN

### DIFF
--- a/ocml/src/sinH.cl
+++ b/ocml/src/sinH.cl
@@ -21,7 +21,7 @@ MATH_MANGLE(sin)(half x)
     s ^= (r.i > (short)1 ? (short)0x8000 : (short)0) ^ (AS_SHORT(x) & (short)0x8000);
 
     if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F16(ax) ?(short)QNANBITPATT_HP16 : s;
+        s = BUILTIN_ISFINITE_F16(ax) ? s : (short)QNANBITPATT_HP16;
     }
 
     return AS_HALF(s);


### PR DESCRIPTION
This pull request fixes BUILTIN_ISFINITE_F16 check that got inverted in sinH.bc in revision 52ea8c43 somehow, resulting in sinh() always returning nan.