### PR TITLE
Make __builtin_generic_class_f{16,32,64}() functions "static inline"

### DIFF
--- a/irif/inc/irif.h
+++ b/irif/inc/irif.h
@@ -169,7 +169,7 @@ static inline half __builtin_generic_clamp_f16(half x, half l, half h) {
     return x < l ? l : (x > h ? h : x);
 }
 
-inline int __builtin_generic_class_f32(float x, int klass) {
+static inline int __builtin_generic_class_f32(float x, int klass) {
     unsigned long ix = *((unsigned long *)&x);
 
     if ((klass & CLASS_PINF) && (ix == PINFBITPATT_SP32)) {
@@ -191,7 +191,7 @@ inline int __builtin_generic_class_f32(float x, int klass) {
     return 0;
 }
 
-inline int __builtin_generic_class_f64(double x, int klass) {
+static inline int __builtin_generic_class_f64(double x, int klass) {
     unsigned long long ix = *((unsigned long long *)&x);
 
     if ((klass & CLASS_PINF) && (ix == PINFBITPATT_DP64)) {
@@ -213,7 +213,7 @@ inline int __builtin_generic_class_f64(double x, int klass) {
     return 0;
 }
 
-inline int __builtin_generic_class_f16(unsigned short x, int klass) {
+static inline int __builtin_generic_class_f16(unsigned short x, int klass) {
     if ((klass & CLASS_PINF) && (x == PINFBITPATT_HP16)) {
         return -1;
     }


### PR DESCRIPTION
Make __builtin_generic_class_f{16,32,64}() functions "static inline" not just inline, like all other functions. Without this, the bytecode emited would not contain any implementation, looking like the following:

```
; Function Attrs: inlinehint norecurse nounwind
declare spir_func i32 @__builtin_generic_class_f16(i16 noundef zeroext, i32 noundef) local_unnamed_addr #1
```

With this change applied the functions are getting inlined properly.

```
; Function Attrs: inlinehint mustprogress nofree norecurse nosync nounwind willreturn memory(none)
define internal spir_func i32 @__builtin_generic_class_f16(i16 noundef zeroext %0) unnamed_addr #1 {
  %2 = and i16 %0, 32767
  %3 = icmp eq i16 %2, 0
  br i1 %3, label %12, label %4

4:                                                ; preds = %1
  %5 = zext i16 %0 to i32
  %6 = and i32 %5, 31744
  %7 = icmp eq i32 %6, 0
  %8 = and i32 %5, 1023
  %9 = icmp ne i32 %8, 0
  %10 = and i1 %7, %9
  %11 = sext i1 %10 to i32
  br label %12

12:                                               ; preds = %4, %1
  %13 = phi i32 [ -1, %1 ], [ %11, %4 ]
  ret i32 %13
}
```

This causes the following failure:

```
CHIP trace [TID 587981] [1705302817.197597560] : hiprtcCompileProgram
CHIP debug [TID 587981] [1705302817.197683876] : hiprtc: Temp directory: '/tmp/chip-temp-98AbNUJW'
CHIP debug [TID 587981] [1705302817.197762429] : HIPCC path: /home/sobomax/projects/chipStar/build/bin/hipcc
CHIP debug [TID 587981] [1705302817.197782153] : Executing shell command ''/home/sobomax/projects/chipStar/build/bin/hipcc' '--cuda-device-only' '-I/home/sobomax/projects/chipStar/HIP/include' '-I/home/sobomax/projects/chipStar/include/hip' '-I/home/sobomax/projects/chipStar/include' '-I/tmp/chip-temp-98AbNUJW' '--include=hip/hip_runtime.h' '-O2' '-c' '/tmp/chip-temp-98AbNUJW/program.hip' '-o' '/tmp/chip-temp-98AbNUJW/program.o' >'/tmp/chip-temp-98AbNUJW/compile.log' 2>&1'
CHIP debug [TID 587981] [1705302817.518160007] : Return code: 0
CHIP debug [TID 587981] [1705302817.518230643] : Removing '/tmp/chip-temp-98AbNUJW'
#include <hip/hip_fp16.h>

typedef union { struct { half x, y, z, w; } __attribute__((aligned(8))); half data[4]; } half4;
__device__ half4 make_half4(half x, half y, half z, half w) { return {x, y, z, w}; }
typedef union { struct { half x, y, z, w, a, b, c, d; } __attribute__((aligned(16))); half data[8]; } half8;
__device__ half8 make_half8(half x, half y, half z, half w, half a, half b, half c, half d) { return {x, y, z, w, a, b, c, d}; }
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
__device__ half16 make_half16(half x, half y, half z, half w, half a, half b, half c, half d,
                              half e, half f, half g, half h, half i, half j, half k, half l) {
                                return {x, y, z, w, a, b, c, d, e, f, g, h, i, j, k, l}; }

#include <hip/hip_common.h>
#if !defined(INFINITY)
#define INFINITY (__builtin_inff())
#endif
#if !defined(NAN)
#define NAN (__builtin_nanf(""))
#endif

  typedef float float8 __attribute__((ext_vector_type(8)));
  __device__ float8 make_float8(float x, float y, float z, float w, float a, float b, float c, float d) { return {x, y, z, w, a, b, c, d}; }
  extern "C" __global__
  void __launch_bounds__ (128, 1) E_4096_2_8_16_4(half* data0, const half* data1, const half* data2, const half* data3) {
  int gidx0 = blockIdx.y; /* 4096 */
  int gidx1 = blockIdx.x; /* 2 */
  int lidx2 = threadIdx.y; /* 8 */
  int lidx3 = threadIdx.x; /* 16 */
  int alu0 = ((gidx0*512)%26624);
  int alu1 = (alu0+(gidx1*32));
  int alu2 = (lidx3*2);
  int alu3 = (alu1+(lidx2*64)+alu2);
  int alu4 = ((alu3%26624)*2);
  bool alu5 = (gidx0<52);
  half val0 = (alu5?*(data1+alu4):(half)(0.0f));
  int alu6 = (((alu3+1)%26624)*2);
  half val1 = (alu5?*(data1+alu6):(half)(0.0f));
  half alu7 = (alu5?(half)(1.5707963267948966f):(half)(0.0f));
  half val2 = (alu5?*(data2+((lidx2+((gidx1+((lidx3+((gidx0*256)%13312))/16))/2))/8)%52):(half)(0.0f));
  half val3 = (alu5?*(data2+((lidx2+((gidx1+((lidx3+((alu0+1)/2))/16))/2))/8)%52):(half)(0.0f));
  int alu8 = (alu1+alu2);
  half val4 = (alu5?*(data3+alu8%64):(half)(0.0f));
  half val5 = (alu5?*(data3+(alu8+1)%64):(half)(0.0f));
  half val6 = (alu5?*(data1+alu4+1):(half)(0.0f));
  half val7 = (alu5?*(data1+alu6+1):(half)(0.0f));
  half alu9 = (val2*val4);
  half alu10 = (val3*val5);
  half alu11 = hsin((half)(0.0f));
  half alu12 = (hsin((alu7-alu9))+alu11);
  half alu13 = (hsin((alu7-alu10))+alu11);
  half alu14 = (alu11+hsin(alu9));
  half alu15 = (alu11+hsin(alu10));
  *((half4*)(data0+(gidx0*1024)+(gidx1*64)+(lidx2*128)+(lidx3*4))) = (half4)make_half4(((val0*alu12)-(val6*alu14)),((val0*alu14)+(val6*alu12)),((val1*alu13)-(val7*alu15)),((val1*alu15)+(val7*alu13)));
}
CHIP debug [TID 587981] [1705302817.528759686] : Bundle entry ID 0 is: 'host-x86_64-unknown-linux--'
CHIP debug [TID 587981] [1705302817.528768609] : Not a SPIR-V triple, ignoring
CHIP debug [TID 587981] [1705302817.528773285] : Bundle entry ID 1 is: 'hip-spirv64----generic'
CHIP debug [TID 587981] [1705302817.528781469] : Finalize module 0x51cb920
CHIP trace [TID 587981] [1705302817.528786028] : filterSPIRV
CHIP warning [TID 587981] [1705302817.528842201] : Missing definition for '__builtin_generic_class_f16'
CHIP debug [TID 587981] [1705302817.528851632] : Compile module 0x51cb920
CHIP trace [TID 587981] [1705302817.528856593] : CHIPModuleLevel0.compile()
CHIP error [TID 587981] [1705302817.576322222] : ZE Build Log:
CHIP error [TID 587981] [1705302817.576349597] : hipErrorTbd (ZE_RESULT_ERROR_MODULE_BUILD_FAILURE ) in /home/sobomax/projects/chipStar/src/backend/Level0/CHIPBackendLevel0.cc:2484:compileIL
```
Poking around generated spir-v code:
```
(tinygrad) sobomax@Super-SIP-Server:~/projects/tinygrad$ spirv-dis hip-spirv-ee8d04.spv
; SPIR-V
; Version: 1.0
; Generator: Khronos LLVM/SPIR-V Translator; 14
; Bound: 463
; Schema: 0
               OpCapability Addresses
               OpCapability Linkage
               OpCapability Kernel
               OpCapability Vector16
               OpCapability Float16Buffer
               OpCapability Int64
               OpCapability Int16
               OpCapability GenericPointer
               OpCapability Int8
          %1 = OpExtInstImport "OpenCL.std"
               OpMemoryModel Physical64 OpenCL
               OpEntryPoint Kernel %456 "E_4096_2_8_16_4" %__spirv_BuiltInWorkgroupId %__spirv_BuiltInLocalInvocationId
               OpExecutionMode %456 ContractionOff
               OpSource OpenCL_C 200000
               OpName %__spirv_BuiltInWorkgroupId "__spirv_BuiltInWorkgroupId"
               OpName %__spirv_BuiltInLocalInvocationId "__spirv_BuiltInLocalInvocationId"
               OpName %__builtin_generic_class_f16 "__builtin_generic_class_f16"
               OpName %union_half4 "union.half4"
               OpName %struct_anon "struct.anon"
               OpName %struct___half "struct.__half"
               OpName %union_anon_0 "union.anon.0"
               OpName %_Z10make_half46__halfS_S_S_ "_Z10make_half46__halfS_S_S_"
               OpName %union_half8 "union.half8"
               OpName %struct_anon_1 "struct.anon.1"
               OpName %_Z10make_half86__halfS_S_S_S_S_S_S_ "_Z10make_half86__halfS_S_S_S_S_S_S_"
               OpName %_Z11make_half166__halfS_S_S_S_S_S_S_S_S_S_S_S_S_S_S_ "_Z11make_half166__halfS_S_S_S_S_S_S_S_S_S_S_S_S_S_S_"
               OpName %_Z11make_float8ffffffff "_Z11make_float8ffffffff"
               OpName %__ocml_sin_f16 "__ocml_sin_f16"
               OpName %struct_redret_2 "struct.redret.2"
               OpName %struct_scret_3 "struct.scret.3"
               OpName %__ocmlpriv_trigred_f16 "__ocmlpriv_trigred_f16"
               OpName %__ocmlpriv_sincosred_f16 "__ocmlpriv_sincosred_f16"
               OpDecorate %__spirv_BuiltInWorkgroupId LinkageAttributes "__spirv_BuiltInWorkgroupId" Import
               OpDecorate %__spirv_BuiltInWorkgroupId Constant
               OpDecorate %__spirv_BuiltInWorkgroupId BuiltIn WorkgroupId
               OpDecorate %__spirv_BuiltInLocalInvocationId LinkageAttributes "__spirv_BuiltInLocalInvocationId" Import
               OpDecorate %__spirv_BuiltInLocalInvocationId Constant
               OpDecorate %__spirv_BuiltInLocalInvocationId BuiltIn LocalInvocationId
               OpDecorate %__builtin_generic_class_f16 LinkageAttributes "__builtin_generic_class_f16" Import
               OpDecorate %11 FuncParamAttr Zext
               OpDecorate %_Z10make_half46__halfS_S_S_ LinkageAttributes "_Z10make_half46__halfS_S_S_" Export
               OpDecorate %23 FuncParamAttr NoAlias
               OpDecorate %23 FuncParamAttr NoCapture
               OpDecorate %23 FuncParamAttr Sret
